### PR TITLE
fix disk usage checks

### DIFF
--- a/metartg/checks/disk.py
+++ b/metartg/checks/disk.py
@@ -13,12 +13,43 @@ def disk_metrics():
     now = int(time())
 
     metrics = {}
+    measured_devices = {}
     for line in stdout.rsplit('\n\n', 2)[1].split('\n')[1:]:
         line = [x for x in line.split(' ') if x]
         device = line[0]
-        if not device in ('sda1', 'md0'):
-            continue
         iostat = IOStat(*line[1:])._asdict()
+        if device == 'dm-0':
+            measured_devices['raid0'] = iostat
+        elif device == 'xvdap1':
+            measured_devices['sda1'] = iostat
+        else:
+            measured_devices[device] = iostat
+
+    # approximating hack to make raid0 stats work for mdadm devices
+    if not 'raid0' in measured_devices and 'md0' in measured_devices:
+        total_avgq = 0.0
+        total_await = 0.0
+        total_svctm = 0.0
+        total_util = 0.0
+        devices = 0.0
+        for device, iostat in measured_devices.items():
+            if device in ('xvdb', 'xvdc', 'xvdd', 'xvde'):
+                devices += 1.0
+                total_avgq += float(iostat['avgq'])
+                total_await += float(iostat['await'])
+                total_svctm += float(iostat['svctm'])
+                total_util += float(iostat['util'])
+
+        raid_stats = measured_devices['md0']
+        raid_stats['avgq'] = total_avgq
+        raid_stats['await'] = total_await / devices
+        raid_stats['svctm'] = total_await / devices
+        raid_stats['util'] = total_util / devices
+
+        measured_devices['raid0'] = raid_stats
+
+    for device in ('raid0', 'sda1'):
+        iostat = measured_devices[device]
         for field in iostat:
             metrics['%s.%s' % (device, field)] = {
                 'ts': now,
@@ -59,3 +90,8 @@ def disk_space_metrics():
 def run_check(callback):
     callback('disk', disk_metrics())
     callback('disk-space', disk_space_metrics())
+
+if __name__ == '__main__':
+    print json.dumps(disk_metrics(), indent=2)
+    print json.dumps(disk_space_metrics(), indent=2)
+

--- a/metartg/server.py
+++ b/metartg/server.py
@@ -407,7 +407,7 @@ for monitservice in services.keys():
 #RRD_GRAPH_TYPES.append(('haproxy-sessions', 'Sessions'))
 
 
-for disk in ('md0', 'sda1'):
+for disk in ('raid0', 'sda1'):
     RRD_GRAPH_DEFS['disk-%s-requests' % disk] = [
         'DEF:rrqm=%%(rrdpath)s/disk/%s.rrqm.rrd:sum:AVERAGE' % disk,
         'DEF:wrqm=%%(rrdpath)s/disk/%s.wrqm.rrd:sum:AVERAGE' % disk,


### PR DESCRIPTION
- fix the check to properly convert iostat device name (still not sure where those are coming from, but it has to do with Xen) to normal device name for sda1
- approximate aggregate numbers for md0 in a way that imitates what iostat appears to do for lvm-managed raid0 devices.
